### PR TITLE
Add qmd formula (v2.0.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     types:
       - labeled
 
+concurrency:
+  group: pr-pull-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: test-bot-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-bot:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: test-bot-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,10 @@ brew install --build-from-source Formula/<name>.rb
 brew test Formula/<name>.rb
 
 # Get the sha256 for a URL (needed when adding/updating a formula)
-brew fetch --force --bottle-disable Formula/<name>.rb
-# or
 curl -L <url> | shasum -a 256
+
+# Regenerate all resource blocks after a version bump (Python formulae)
+brew update-python-resources Formula/<name>.rb
 
 # Lint formula style
 brew style Formula/<name>.rb
@@ -66,5 +67,41 @@ brew style --fix Formula/<name>.rb
 
 1. Update `url` to point to the new release tarball
 2. Update `sha256` (use `curl -L <url> | shasum -a 256`)
-3. Run `brew audit Formula/<name>.rb` and `brew style Formula/<name>.rb`
-4. Run `brew install --build-from-source Formula/<name>.rb && brew test Formula/<name>.rb`
+3. For Python formulae, run `brew update-python-resources Formula/<name>.rb` to regenerate resource blocks
+4. Run `brew audit Formula/<name>.rb` and `brew style Formula/<name>.rb`
+5. Run `brew install --build-from-source Formula/<name>.rb && brew test Formula/<name>.rb`
+
+## Bottling workflow (CI)
+
+Changes go through PRs, not direct pushes to `main`. The flow:
+
+1. Push changes on a branch, open a PR
+2. `tests.yml` runs `brew test-bot` — builds bottles and uploads them as artifacts
+3. When CI is green, apply the `pr-pull` label to the PR
+4. `publish.yml` runs `brew pr-pull` — downloads artifacts, creates a GitHub Release with the bottle attached, updates the `bottle do` block in the formula, pushes to `main`, and closes the PR
+
+Do **not** merge the PR normally — the `pr-pull` label is what triggers publishing.
+
+## Python formulae
+
+- Use `include Language::Python::Virtualenv` and `virtualenv_install_with_resources`
+- Declare every transitive dependency as a `resource` block with its PyPI sdist URL and sha256
+- Use `brew update-python-resources` to auto-regenerate resource blocks after version bumps
+- **Verify all PyPI URLs** — path hashes in PyPI URLs can have typos; confirm with `curl -L <url> | shasum -a 256`
+- **pydantic-core must be pinned to the exact version pydantic requires** — do not use the latest pydantic-core independently; check the pydantic release's `requires_dist` for the exact pin
+- **Runtime linkage deps**: add `depends_on "openssl@3"` when `cryptography` is in the dep tree; add `depends_on "libyaml"` when `pyyaml` is in the dep tree
+- Formulae with `pydantic-core`, `rpds-py`, or `cryptography` require `depends_on "rust" => :build` and `depends_on "pkgconf" => :build`
+
+## Node/npm formulae
+
+- Use `require "language/node"` at the top of the file and `include Language::Node`
+- `std_npm_args` takes no arguments — pass the prefix separately: `system "npm", "install", "--prefix=#{libexec}", *std_npm_args`
+- For TypeScript packages: prefer the npm registry tarball over the GitHub source tarball when the npm tarball includes pre-built `dist/` — avoids needing TypeScript as a build dep
+- Check whether the package's `bin` script uses `node` or `bun` at runtime; the npm tarball won't have a `bun.lock`, so the script will fall back to `node` automatically
+
+## CI gotchas
+
+- `brew test-bot --only-tap-syntax` scans **all files** in the tap, not just `.rb` files — any `sha256` value in CLAUDE.md or other docs must be a valid 64-char hex string
+- `brew test-bot` only builds bottles for formulae that changed in the PR (detected by git diff), but runs syntax checks across the whole tap
+- `macos-15-xlarge` (Intel) is a paid GitHub Actions runner — the workflow uses `macos-15` (ARM) only to stay on the free tier
+- Before writing a formula test, verify what flags the CLI actually supports — not all tools have `--version`; use `--help` and `assert_match` against known output instead

--- a/Formula/qmd.rb
+++ b/Formula/qmd.rb
@@ -1,3 +1,5 @@
+require "language/node"
+
 class Qmd < Formula
   include Language::Node
 
@@ -11,7 +13,7 @@ class Qmd < Formula
   depends_on "node"
 
   def install
-    system "npm", "install", *std_npm_install_args(libexec)
+    system "npm", "install", *std_npm_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 

--- a/Formula/qmd.rb
+++ b/Formula/qmd.rb
@@ -1,0 +1,21 @@
+class Qmd < Formula
+  include Language::Node
+
+  desc "Mini CLI search engine for docs, knowledge bases, and meeting notes"
+  homepage "https://github.com/tobi/qmd"
+  url "https://registry.npmjs.org/@tobilu/qmd/-/qmd-2.0.1.tgz"
+  sha256 "4f7156f50decebee8422f5e49e1b8b42db08b37b8e33446d83b28e391875a979"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/qmd --version")
+  end
+end

--- a/Formula/qmd.rb
+++ b/Formula/qmd.rb
@@ -13,7 +13,7 @@ class Qmd < Formula
   depends_on "node"
 
   def install
-    system "npm", "install", *std_npm_args(libexec)
+    system "npm", "install", "--prefix=#{libexec}", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 


### PR DESCRIPTION
Adds a formula for [qmd](https://github.com/tobi/qmd) — a local CLI search engine for docs and knowledge bases using embeddings and SQLite.

Source is the npm tarball from `@tobilu/qmd` which includes pre-built `dist/` (no TypeScript compilation required). Native dependencies (`better-sqlite3`, `node-llama-cpp`) are compiled from source via `npm install`.

Requires `cmake` at build time for `node-llama-cpp`'s native compilation.