### PR TITLE
qmd: use env_script to ensure Homebrew node is used at runtime

### DIFF
--- a/Formula/qmd.rb
+++ b/Formula/qmd.rb
@@ -18,7 +18,7 @@ class Qmd < Formula
   depends_on "node"
 
   def install
-    system "npm", "install", "--prefix=#{libexec}", *std_npm_args
+    system "npm", "install", *std_npm_args(ignore_scripts: false)
     bin.env_script_all_files libexec/"bin", PATH: "#{Formula["node"].opt_bin}:$PATH"
   end
 

--- a/Formula/qmd.rb
+++ b/Formula/qmd.rb
@@ -19,7 +19,7 @@ class Qmd < Formula
 
   def install
     system "npm", "install", "--prefix=#{libexec}", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.env_script_all_files libexec/"bin", PATH: "#{Formula["node"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/qmd.rb
+++ b/Formula/qmd.rb
@@ -19,7 +19,7 @@ class Qmd < Formula
 
   def install
     system "npm", "install", *std_npm_args(ignore_scripts: false)
-    bin.env_script_all_files libexec/"bin", PATH: "#{Formula["node"].opt_bin}:$PATH"
+    (bin/"qmd").write_env_script libexec/"bin/qmd", PATH: "#{Formula["node"].opt_bin}:$PATH"
   end
 
   test do


### PR DESCRIPTION
`better-sqlite3` is a native addon compiled against Homebrew's node during the bottle build. If the user has a different Node.js version in their PATH (e.g. via nvm), the ABI won't match and the addon fails to load.

Switch from `bin.install_symlink` to `bin.env_script_all_files` so that Homebrew's own node binary is prepended to PATH when `qmd` runs, ensuring ABI compatibility with the compiled native addon.