### PR TITLE
chore: enforce 7-day supply-chain cooldown on dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # GitHub Actions workflows — hold new versions for a cooldown window so a
+  # compromised release has time to be detected and yanked before it lands.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Supply-chain cooldown (7-day minimum release age)

Part of an org-wide rollout hardening get2knowio repos against supply-chain attacks. A newly published dependency version must age **7 days** before it can be installed/resolved or proposed by Dependabot — giving time for a malicious release to be detected and yanked. Security updates are never delayed (Dependabot cooldown applies to *version* updates only).

Config schema verified against current official docs (not training data).

### Changes
- **Dependabot** — created `.github/dependabot.yml` with `cooldown: { default-days: 7 }` on the `github-actions` entry (the only dependency ecosystem in this repo).
